### PR TITLE
Speeds up the boba-regenerate tool

### DIFF
--- a/boba-chain-ops/cmd/boba-regenerate/main.go
+++ b/boba-chain-ops/cmd/boba-regenerate/main.go
@@ -50,7 +50,7 @@ func main() {
 			&cli.StringFlag{
 				Name:    "polling-interval",
 				Usage:   "Interval between sending a request to the L2 node to build a new block",
-				Value:   "100ms",
+				Value:   "1s",
 				EnvVars: []string{"POLLING_INTERVAL"},
 			},
 			&cli.Int64Flag{
@@ -58,6 +58,7 @@ func main() {
 				Usage:   "Block number at which the hard fork will happen",
 				Value:   0,
 				EnvVars: []string{"HARD_FORK_BLOCK_NUMBER"},
+				Required: true,
 			},
 			&cli.StringFlag{
 				Name:  "log-level",


### PR DESCRIPTION
Restructure boba-regenerate to use a loop rather than a periodic timer.

Combine the two ForkchoiceUpdateV1 calls into one per block, adding the previous block to the chain while also supplying the next payload.