### PR TITLE
Use a config directory for erigon and op-node

### DIFF
--- a/ops-bedrock/devnet-up.sh
+++ b/ops-bedrock/devnet-up.sh
@@ -34,6 +34,7 @@ L2_URL="http://localhost:9545"
 
 OP_NODE="$PWD/op-node"
 CONTRACTS_BEDROCK="$PWD/packages/contracts-bedrock"
+OPS_BEDROCK="$PWD/ops-bedrock"
 NETWORK=devnetL1
 DEVNET="$PWD/.devnet"
 
@@ -57,11 +58,17 @@ function wait_up {
   echo "Done!"
 }
 
-mkdir -p ./.devnet
+mkdir -p $DEVNET
 
 # Regenerate the L1 genesis file if necessary. The existence of the genesis
 # file is used to determine if we need to recreate the devnet's state folder.
 if [ ! -f "$DEVNET/done" ]; then
+  echo "Copying devnet keys"
+
+  cp $OPS_BEDROCK/test-jwt-secret.txt $DEVNET/
+  cp $OPS_BEDROCK/p2p-node-key.txt $DEVNET/
+  cp $OPS_BEDROCK/op-batcher-key.txt $DEVNET/
+
   echo "Regenerating genesis files"
 
   TIMESTAMP=$(date +%s | xargs printf '0x%x')

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -46,8 +46,7 @@ services:
       - "8060:6060"
     volumes:
       - "l2_data:/db"
-      - "${PWD}/../.devnet/genesis-l2.json:/genesis.json"
-      - "${PWD}/test-jwt-secret.txt:/config/test-jwt-secret.txt"
+      - "${PWD}/../.devnet:/config"
     entrypoint:  # pass the L2 specific flags by overriding the entry-point and adding extra arguments
       - "/bin/sh"
       - "/home/boba/l2-erigon.sh"
@@ -70,7 +69,7 @@ services:
       --verifier.l1-confs=0
       --p2p.disable
       --p2p.sequencer.key=8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba
-      --rollup.config=/rollup.json
+      --rollup.config=/config/rollup.json
       --rpc.addr=0.0.0.0
       --rpc.port=8545
       --p2p.listen.ip=0.0.0.0
@@ -92,10 +91,7 @@ services:
       - "7300:7300"
       - "6060:6060"
     volumes:
-      - "${PWD}/p2p-sequencer-key.txt:/config/p2p-sequencer-key.txt"
-      - "${PWD}/p2p-node-key.txt:/config/p2p-node-key.txt"
-      - "${PWD}/test-jwt-secret.txt:/config/test-jwt-secret.txt"
-      - "${PWD}/../.devnet/rollup.json:/rollup.json"
+      - "${PWD}/../.devnet:/config"
       - op_log:/op_log
 
   op-proposer:

--- a/ops-bedrock/l2-erigon.sh
+++ b/ops-bedrock/l2-erigon.sh
@@ -46,7 +46,7 @@ RPC_FLAGS=" \
 
 if [ ! -f ${DATADIR}/init_done ] ; then
   echo "Chain init"
-  erigon ${COMMON_FLAGS} init /genesis.json
+  erigon ${COMMON_FLAGS} init /config/genesis-l2.json
   echo "Creating keyfile"
   echo "2e0834786285daccd064ca17f1654f67b4aef298acbb82cef9ec422fb4975622" > ${DATADIR}/nodekey
   touch ${DATADIR}/init_done


### PR DESCRIPTION
Mount a single "config" directory for the l2 and op-node services
rather than using a file-by-file mapping in the docker-compose.yml.

This should simplify our AWS configuration. 

 Changes to be committed:
	modified:   ops-bedrock/devnet-up.sh
	modified:   ops-bedrock/docker-compose.yml
	modified:   ops-bedrock/l2-erigon.sh
