### PR TITLE
Re-enable p2p test

### DIFF
--- a/op-e2e/external_erigon/test_parms.json
+++ b/op-e2e/external_erigon/test_parms.json
@@ -6,7 +6,6 @@
     "TestVerifyL2OutputRootEmptyBlock":"This test depends debug_dbGet, a custom geth RPC which is not generally suported by other eth clients",
     "TestVerifyL2OutputRootEmptyBlockDetached":"This test depends debug_dbGet, a custom geth RPC which is not generally suported by other eth clients",
     "TestPendingGasLimit":"This test requires changes that neither Geth nor Erigon support as CLI flags",
-    "TestSystemP2PAltSync":"TODO This used to work and must be fixed",
     "TestCannonDefendStep":"TODO This is a new failure that should be investigated",
     "TestMultipleCannonGames":"TODO This is a new failure that should be investigated",
     "TestCannonDisputeGame":"TODO This is a new failure that should be investigated",

--- a/op-erigon/go.mod
+++ b/op-erigon/go.mod
@@ -248,9 +248,13 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ledgerwatch/erigon => github.com/bobanetwork/v3-erigon v1.9.7-0.20230906193026-cd3f24255785
+replace github.com/ledgerwatch/erigon => github.com/bobanetwork/v3-erigon v1.9.7-0.20230915163742-fd98f9a0a12c
+
+// replace github.com/ledgerwatch/erigon => ../../erigon
 
 replace github.com/ledgerwatch/erigon-lib => github.com/bobanetwork/v3-erigon-lib v0.0.0-20230906160529-b1ac19ad04da
+
+// replace github.com/ledgerwatch/erigon-lib => ../../erigon-lib
 
 replace github.com/tendermint/tendermint => github.com/bnb-chain/tendermint v0.31.12
 

--- a/op-erigon/go.sum
+++ b/op-erigon/go.sum
@@ -120,8 +120,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bits-and-blooms/bitset v1.5.0 h1:NpE8frKRLGHIcEzkR+gZhiioW1+WbYV6fKwD6ZIpQT8=
 github.com/bits-and-blooms/bitset v1.5.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
-github.com/bobanetwork/v3-erigon v1.9.7-0.20230906193026-cd3f24255785 h1:Y1A/M+HZBvHZL5NrffTIQKwfdW3c+6qW/UPxz3FN/O4=
-github.com/bobanetwork/v3-erigon v1.9.7-0.20230906193026-cd3f24255785/go.mod h1:CsR3ycLl46ImMeklYarz00K3axOILMsiNSkYGPZWqjM=
+github.com/bobanetwork/v3-erigon v1.9.7-0.20230915163742-fd98f9a0a12c h1:fvyLngTfofb5+7z9SZZfk93+mo+hThRtuuuSvA02DIo=
+github.com/bobanetwork/v3-erigon v1.9.7-0.20230915163742-fd98f9a0a12c/go.mod h1:CsR3ycLl46ImMeklYarz00K3axOILMsiNSkYGPZWqjM=
 github.com/bobanetwork/v3-erigon-lib v0.0.0-20230906160529-b1ac19ad04da h1:xSM/FkfEqc1+M8Bemhk6cnhVWHH8lv76leHbVcQjGOk=
 github.com/bobanetwork/v3-erigon-lib v0.0.0-20230906160529-b1ac19ad04da/go.mod h1:khV70zMPfHeF5O/lk/2w6phTSi9u4PusY6qkJKjL+/E=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=


### PR DESCRIPTION
Bumps the version of erigon to include the Regolith fixes, and re-enables the failing P2P test.