### PR TITLE
Disable geth ipc for external_geth

### DIFF
--- a/op-e2e/external_geth/main.go
+++ b/op-e2e/external_geth/main.go
@@ -115,6 +115,7 @@ func execute(binPath string, config external.Config) (*gethSession, error) {
 		"--ws.api", "debug,eth,txpool,net,engine",
 		"--syncmode=full",
 		"--nodiscover",
+		"--ipcdisable",
 		"--port", "0",
 		"--maxpeers", "0",
 		"--networkid", strconv.FormatUint(config.ChainID, 10),


### PR DESCRIPTION
Binding the IPC socket causes problems when the temp dir is adequately long (more than 104 characters).  This is especially problematic for Mac users as their temp dir is already quite long.