### PR TITLE
Kill erigon db generation process

### DIFF
--- a/op-e2e/external_erigon/main.go
+++ b/op-e2e/external_erigon/main.go
@@ -81,7 +81,9 @@ func initialize(binPath string, config external.Config) error {
 		"init", config.GenesisPath,
 	)
 	if err := cmd.Run(); err != nil {
-		cmd.Process.Kill()
+		if err := cmd.Process.Kill(); err != nil {
+			return fmt.Errorf("could not kill process: %w", err)
+		}
 		return err
 	}
 	return nil

--- a/op-e2e/external_erigon/main.go
+++ b/op-e2e/external_erigon/main.go
@@ -80,7 +80,11 @@ func initialize(binPath string, config external.Config) error {
 		"--datadir", config.DataDir,
 		"init", config.GenesisPath,
 	)
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		cmd.Process.Kill()
+		return err
+	}
+	return nil
 }
 
 type erigonSession struct {


### PR DESCRIPTION
This code prevent a rare case that the db generation process can't be killed on Mac and block the following tests