### PR TITLE
Stabilize boba-chain-ops unit tests

### DIFF
--- a/boba-chain-ops/ether/migrate_test.go
+++ b/boba-chain-ops/ether/migrate_test.go
@@ -236,7 +236,7 @@ func TestMigrateBalances(t *testing.T) {
 					predeploys.LegacyERC20ETHAddr: types.GenesisAccount{
 						Storage: map[common.Hash]common.Hash{
 							CalcOVMETHTotalSupplyKey():                                    common.BigToHash(common.Big2),
-							CalcOVMETHStorageKey(common.Address{1}):                       common.BigToHash(common.Big1),
+							CalcOVMETHStorageKey(common.Address{3}):                       common.BigToHash(common.Big1),
 							CalcAllowanceStorageKey(common.Address{1}, common.Address{2}): common.BigToHash(common.Big1),
 							CalcAllowanceStorageKey(common.Address{1}, common.Address{3}): common.BigToHash(common.Big1),
 						},


### PR DESCRIPTION
I can't locate the actual issue, but I assume the problem is caused by the mapping tests. I verify this fix via running this command multiple times and finding no issues now.
```
go test -timeout 30s -run ^TestMigrateBalances$ github.com/bobanetwork/v3-anchorage/boba-chain-ops/ether -count=100
```