### PR TITLE
Add RPC timeout for op-node

### DIFF
--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -78,10 +79,11 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher, eng L2API, cf
 	// setup RPC server for rollup node, hooked to the actor as backend
 	m := &testutils.TestRPCMetrics{}
 	backend := &l2VerifierBackend{verifier: rollupNode}
+	rpcTimeout := 10 * time.Second
 	apis := []rpc.API{
 		{
 			Namespace:     "optimism",
-			Service:       node.NewNodeAPI(cfg, eng, backend, log, m),
+			Service:       node.NewNodeAPI(cfg, eng, rpcTimeout, backend, log, m),
 			Public:        true,
 			Authenticated: false,
 		},

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -122,6 +122,7 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 					ListenAddr:  "127.0.0.1",
 					ListenPort:  0,
 					EnableAdmin: true,
+					RpcTimout:   time.Second * 10,
 				},
 				L1EpochPollInterval:         time.Second * 2,
 				RuntimeConfigReloadInterval: time.Minute * 10,

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -708,6 +708,7 @@ func TestSystemP2PAltSync(t *testing.T) {
 			ListenAddr:  "127.0.0.1",
 			ListenPort:  0,
 			EnableAdmin: true,
+			RpcTimout:   10 * time.Second,
 		},
 		P2P:                 &p2p.Prepared{HostP2P: h, EnableReqRespSync: true},
 		Metrics:             rollupNode.MetricsConfig{Enabled: false}, // no metrics server

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -67,6 +67,12 @@ var (
 		Usage:   "File path used to persist state changes made via the admin API so they persist across restarts. Disabled if not set.",
 		EnvVars: prefixEnvVars("RPC_ADMIN_STATE"),
 	}
+	RPCTimeout = &cli.DurationFlag{
+		Name:    "rpc.timeout",
+		Usage:   "Timeout for RPC requests",
+		Value:   time.Second * 10,
+		EnvVars: prefixEnvVars("RPC_TIMEOUT"),
+	}
 	L1TrustRPC = &cli.BoolFlag{
 		Name:    "l1.trustrpc",
 		Usage:   "Trust the L1 RPC, sync faster at risk of malicious/buggy RPC providing bad or inconsistent L1 data",
@@ -284,6 +290,7 @@ var optionalFlags = []cli.Flag{
 	L1EpochPollIntervalFlag,
 	RuntimeConfigReloadIntervalFlag,
 	RPCEnableAdmin,
+	RPCTimeout,
 	RPCAdminPersistence,
 	MetricsEnabledFlag,
 	MetricsAddrFlag,

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -98,9 +98,9 @@ func (n *nodeAPI) OutputAtBlock(ctx context.Context, number hexutil.Uint64) (*et
 		return nil, fmt.Errorf("failed to get L2 block ref with sync status: %w", err)
 	}
 
-	contextWithTimeout, cancel := context.WithTimeout(context.Background(), n.rpcTimeout)
+	contextWithTimeout, cancel := context.WithTimeout(ctx, n.rpcTimeout)
 	output, err := n.client.OutputV0AtBlock(contextWithTimeout, ref.Hash)
-	cancel()
+	defer cancel()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get L2 output at block %s: %w", ref, err)
 	}

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -98,7 +98,7 @@ func (n *nodeAPI) OutputAtBlock(ctx context.Context, number hexutil.Uint64) (*et
 		return nil, fmt.Errorf("failed to get L2 block ref with sync status: %w", err)
 	}
 
-	contextWithTimeout, cancel := context.WithTimeout(ctx, n.rpcTimeout)
+	contextWithTimeout, cancel := context.WithTimeout(context.Background(), n.rpcTimeout)
 	output, err := n.client.OutputV0AtBlock(contextWithTimeout, ref.Hash)
 	cancel()
 	if err != nil {

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -99,8 +99,8 @@ func (n *nodeAPI) OutputAtBlock(ctx context.Context, number hexutil.Uint64) (*et
 	}
 
 	contextWithTimeout, cancel := context.WithTimeout(ctx, n.rpcTimeout)
-	defer cancel()
 	output, err := n.client.OutputV0AtBlock(contextWithTimeout, ref.Hash)
+	cancel()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get L2 output at block %s: %w", ref, err)
 	}

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -69,20 +70,22 @@ func (n *adminAPI) SequencerActive(ctx context.Context) (bool, error) {
 }
 
 type nodeAPI struct {
-	config *rollup.Config
-	client l2EthClient
-	dr     driverClient
-	log    log.Logger
-	m      metrics.RPCMetricer
+	config     *rollup.Config
+	client     l2EthClient
+	rpcTimeout time.Duration
+	dr         driverClient
+	log        log.Logger
+	m          metrics.RPCMetricer
 }
 
-func NewNodeAPI(config *rollup.Config, l2Client l2EthClient, dr driverClient, log log.Logger, m metrics.RPCMetricer) *nodeAPI {
+func NewNodeAPI(config *rollup.Config, l2Client l2EthClient, rpcTimeout time.Duration, dr driverClient, log log.Logger, m metrics.RPCMetricer) *nodeAPI {
 	return &nodeAPI{
-		config: config,
-		client: l2Client,
-		dr:     dr,
-		log:    log,
-		m:      m,
+		config:     config,
+		client:     l2Client,
+		rpcTimeout: rpcTimeout,
+		dr:         dr,
+		log:        log,
+		m:          m,
 	}
 }
 
@@ -95,7 +98,9 @@ func (n *nodeAPI) OutputAtBlock(ctx context.Context, number hexutil.Uint64) (*et
 		return nil, fmt.Errorf("failed to get L2 block ref with sync status: %w", err)
 	}
 
-	output, err := n.client.OutputV0AtBlock(ctx, ref.Hash)
+	contextWithTimeout, cancel := context.WithTimeout(ctx, n.rpcTimeout)
+	defer cancel()
+	output, err := n.client.OutputV0AtBlock(contextWithTimeout, ref.Hash)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get L2 output at block %s: %w", ref, err)
 	}

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -66,6 +66,7 @@ type RPCConfig struct {
 	ListenAddr  string
 	ListenPort  int
 	EnableAdmin bool
+	RpcTimout   time.Duration
 }
 
 func (cfg *RPCConfig) HttpEndpoint() string {

--- a/op-node/node/server.go
+++ b/op-node/node/server.go
@@ -28,7 +28,7 @@ type rpcServer struct {
 }
 
 func newRPCServer(ctx context.Context, rpcCfg *RPCConfig, rollupCfg *rollup.Config, l2Client l2EthClient, dr driverClient, log log.Logger, appVersion string, m metrics.Metricer) (*rpcServer, error) {
-	api := NewNodeAPI(rollupCfg, l2Client, dr, log.New("rpc", "node"), m)
+	api := NewNodeAPI(rollupCfg, l2Client, rpcCfg.RpcTimout, dr, log.New("rpc", "node"), m)
 	// TODO: extend RPC config with options for WS, IPC and HTTP RPC connections
 	endpoint := net.JoinHostPort(rpcCfg.ListenAddr, strconv.Itoa(rpcCfg.ListenPort))
 	r := &rpcServer{

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -81,6 +81,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 			ListenAddr:  ctx.String(flags.RPCListenAddr.Name),
 			ListenPort:  ctx.Int(flags.RPCListenPort.Name),
 			EnableAdmin: ctx.Bool(flags.RPCEnableAdmin.Name),
+			RpcTimout:   ctx.Duration(flags.RPCTimeout.Name),
 		},
 		Metrics: node.MetricsConfig{
 			Enabled:    ctx.Bool(flags.MetricsEnabledFlag.Name),


### PR DESCRIPTION
This `RPCTimeout` flag is used to set the timeout for the `eth_getProof` request, so we can let op-node wait for the response longer and op-proposer can get the result from the op-node.